### PR TITLE
Fix for OUJS

### DIFF
--- a/src/userscript.js
+++ b/src/userscript.js
@@ -10,7 +10,7 @@
 // @supportURL https://github.com/Shywim/github-repo-size/issues
 // @author Matthieu Harlé
 // @copyright 2017, Matthieu Harlé (https://matthieuharle.com)
-// @license MIT (https://github.com/Shywim/github-repo-size/blob/master/LICENSE.md)
+// @license MIT; https://github.com/Shywim/github-repo-size/blob/master/LICENSE.md
 // @version 1.2.0
 // ==/UserScript==
 


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing and specific format that's been around for a long time.

This change is syntactically equivalent.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff