### PR TITLE
Fix css selector, center the size element, and wait one second for GitHub to finish loading

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,9 @@ export const GITHUB_API_V3 = 'https://api.github.com/repos/'
 export const REPO_STATS_CLASS = 'numbers-summary'
 export const REPO_REFRESH_STATS_QUERY =
   'div.d-flex.flex-shrink-0.gap-2'
+  //'div.d-flex.flex-shrink-0.gap-2 [aria-labelledby="folders-and-files"]'
+  //'div.d-flex.flex-shrink-0.gap-2 div td tr tbody table[aria-labelledby="folders-and-files"]'
+  //'div.d-flex.flex-shrink-0.gap-2 div.Box-sc-g0xbh4-0.brJRqk table[aria-labelledby="folders-and-files"]'
 export const REPO_SIZE_ID = 'addon-repo-size'
 export const SIZE_KILO = 1024
 export const UNITS = [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ export const GITHUB_API = 'https://api.github.com/graphql'
 export const GITHUB_API_V3 = 'https://api.github.com/repos/'
 export const REPO_STATS_CLASS = 'numbers-summary'
 export const REPO_REFRESH_STATS_QUERY =
-  '.repository-content .Box-header .Details ul'
+  'div.d-flex.flex-shrink-0.gap-2'
 export const REPO_SIZE_ID = 'addon-repo-size'
 export const SIZE_KILO = 1024
 export const UNITS = [

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -87,6 +87,7 @@ export const createSizeWrapperElement = async (
   const li = document.createElement('li')
   li.id = REPO_SIZE_ID
   li.className = 'ml-0 ml-md-3'
+  li.style.cssText = "align-content: center"
 
   li.innerHTML = `
   <details id="${MODAL_ID}-size-stat-wrapper" class="details-reset details-overlay details-overlay-dark">


### PR DESCRIPTION
The CSS selector has not been updated in the past three years. GitHub has changed the class of the statistics element, which caused the size stat to not show up at all. I fixed that, then noticed the size element was not centered vertically. Fixed that, and then it doesn't show up when switching either between branches or when switching from the main page of a repository (Code tab) and the Issues tab and then back.

The code in the third commit uses a combination of a `MutationObserver` and `setInterval` to keep trying to add the element every second after _injectRepoSize()_ is called during a AJAX event.